### PR TITLE
better global handling

### DIFF
--- a/R/6-tsna.R
+++ b/R/6-tsna.R
@@ -9,7 +9,7 @@
 #   n_reps = 100, number of simulation to run
 #   n_cores, number of HPC core to use
 
-options(future.globals.maxSize = Inf)  # sets limit to 700 MiB
+# options(future.globals.maxSize = Inf)  # sets limit to 700 MiB
 
 # Packages
 library(tsna)
@@ -27,50 +27,21 @@ layers <- c("Home", "School", "Work", "Nonhome")
 ## file name of the outputted files
 file.name_out <- paste0(
   "data/frp_outputs/frp_length_",
-  layer, "__", 
-  network,"__", 
+  layer, "__",
+  network,"__",
   percent_target_pop, ".Rds"
 )
 
-# Loading edgelist
- if (layer %in%  layers) { # when the analysis is conducted for each layer individually 
-  el_cuml <- readRDS( paste0(
-    "data/netsim_outputs/el_cuml__", 
-    layer, "__", 
-    network,"__",  
-    percent_target_pop, ".Rds"
-    ))
-} else if (layer == "All") { # when the edgelist to be analyzed is the individual layer
-
-  # reading in individual layers
-  file.name_in <- paste0(
-    "data/netsim_outputs/el_cuml__", 
-    layers, "__", 
-    network,"__",  
-    percent_target_pop, ".Rds")
-  
-  names(file.name_in) <- layers
-  
-  el_cuml_home <- readRDS(file.name_in[["Home"]])
-  el_cuml_school <- readRDS(file.name_in[["School"]])
-  el_cuml_work <- readRDS(file.name_in[["Work"]])
-  el_cuml_nonhome <- readRDS(file.name_in[["Nonhome"]])
-  
-  # combining edgelists of different layers
-  el_cuml <- future_lapply(seq_len(n_reps), \(i) {
-    dedup_cumulative_edgelist(dplyr::bind_rows(
-      el_cuml_home[[i]],
-      el_cuml_school[[i]],
-      el_cuml_work[[i]],
-      el_cuml_nonhome[[i]]
-    ))
-  })
-  
-}
-
-
-# Calculating FRP length for each node and time step for all simulation iterations
 frp_lengths <- future_lapply(seq_len(n_reps), \(i) {
+  els_path <- paste0("data/netsim_outputs__", i, ".rds")
+  els <- readRDS(els_path)
+
+  if (layer %in%  layers) { # when the analysis is conducted for each layer individually
+    el_cuml <- els[[layer]]
+  } else if (layer == "All") {
+    el_cuml <- dedup_cumulative_edgelist(dplyr::bind_rows(els))
+  }
+
   get_forward_reachable(
     el_cuml[[i]],
     from_step = 1,
@@ -79,12 +50,9 @@ frp_lengths <- future_lapply(seq_len(n_reps), \(i) {
   )$lengths #outputting the FRP length data frame
 })
 
-
-
 # The following script is for github, which creates an folder at HPC when the corresponding folder at local is empty
 out_dir <- "data/frp_outputs"
 if (!dir_exists(out_dir)) dir_create(out_dir)
 
 # Outputting FRP result
 saveRDS(frp_lengths, file = file.name_out)
-

--- a/R/utils-refactor_files.R
+++ b/R/utils-refactor_files.R
@@ -1,0 +1,27 @@
+#   network = "Rural"/"Urban"
+#   percent_target_pop = 0.1/0.4/1
+#   n_reps = 100, number of simulation to run
+
+layers <- c("Home", "School", "Work", "Nonhome")
+file.name_in <- paste0(
+  "data/netsim_outputs/el_cuml__",
+  layers, "__",
+  network,"__",
+  percent_target_pop, ".Rds"
+)
+
+el_cuml_home    <- readRDS(file.name_in[["Home"]])
+el_cuml_school  <- readRDS(file.name_in[["School"]])
+el_cuml_work    <- readRDS(file.name_in[["Work"]])
+el_cuml_nonhome <- readRDS(file.name_in[["Nonhome"]])
+
+for (i in seq_len(n_reps)) {
+  els_path <- paste0("data/netsim_outputs__", i, ".rds")
+  els <- list(
+    home    = el_cuml_home[[i]],
+    school  = el_cuml_school[[i]],
+    work    = el_cuml_work[[i]],
+    nonhome = el_cuml_nonhome[[i]]
+  )
+  saveRDS(els, els_path)
+}

--- a/R/workflow-tsna.R
+++ b/R/workflow-tsna.R
@@ -14,6 +14,26 @@ wf <- make_em_workflow("frp_r_0.1_0203_1st_try", override = TRUE)
 
 
 
+# netsim
+wf <- add_workflow_step(
+  wf_summary = wf,
+  step_tmpl = step_tmpl_do_call_script(
+    r_script = "./R/utils-refactor_files.R",
+    args = list(
+      hpc_context = TRUE,
+      network = "Rural",
+      percent_target_pop = "0.1",
+      n_reps = 100
+    ),
+    setup_lines = hpc_node_setup
+  ),
+  sbatch_opts = list(
+    "cpus-per-task" = est_cores,
+    "time" = "4:00:00",
+    "mem" = "0"
+  )
+)
+
 # FRP calculation
 wf <- add_workflow_step(
   wf_summary = wf,
@@ -36,4 +56,3 @@ wf <- add_workflow_step(
     "mem" = "0"
   )
 )
-


### PR DESCRIPTION
I made the following changes:

Now the workflow has  a first step (utils-refactor_files.R) that refactors the files. At the end of it, instead of having a file per layer containing all the replications, we have a file per replications containing all the layers

On the next step (6-tsna) the reading is done inside of the parallel environment. Each replication reads only the file corresponding to it's replication number. This way the memory usage for each worker is way lower.

